### PR TITLE
chore: hide start icon when loading

### DIFF
--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -55,7 +55,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const classes = twMerge(
       'btn',
       className,
-      clsx((startIcon || endIcon) && 'gap-2', {
+      clsx(
+        ((startIcon && !loading) || endIcon) && 'gap-2',
+      {
         [`btn-${size}`]: size,
         [`btn-${shape}`]: shape,
         [`btn-${variant}`]: variant,
@@ -87,7 +89,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           style={style}
           disabled={disabled}
         >
-          {startIcon && startIcon}
+          {startIcon && !loading && startIcon}
           {children}
           {endIcon && endIcon}
         </button>


### PR DESCRIPTION
Before:

<img width="219" alt="Screen Shot 2022-03-16 at 2 01 04 AM" src="https://user-images.githubusercontent.com/64439681/158526403-1bb7aa69-87d6-40ab-8b5d-28ce3d61d581.png">

After:

<img width="187" alt="Screen Shot 2022-03-16 at 2 00 46 AM" src="https://user-images.githubusercontent.com/64439681/158526420-73320a83-9391-4ca8-bf69-4c5c1079f659.png">

