### PR TITLE
feat: made collapse more 'react' compatible

### DIFF
--- a/src/Collapse/Collapse.stories.tsx
+++ b/src/Collapse/Collapse.stories.tsx
@@ -1,61 +1,176 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import Collapse, { CollapseProps } from '.'
+import Swap from '../Swap'
 
 export default {
   title: 'Data Display/Collapse',
   component: Collapse,
 } as Meta
 
-const Template: Story<CollapseProps> = (args) => {
+const Template: Story<CollapseProps> = ({ children, ...args }) => {
+  return <Collapse {...args}>{children}</Collapse>
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Focus or click me to see content
+    </Collapse.Title>,
+    <Collapse.Content>
+      By default, blurring does not close me.
+    </Collapse.Content>,
+  ],
+}
+
+export const ToggleWithFocus = Template.bind({})
+ToggleWithFocus.args = {
+  focusOpens: true,
+  blurCloses: true,
+  clickCloses: false,
+  clickOpens: false,
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Focus me to see content
+    </Collapse.Title>,
+    <Collapse.Content>
+      Clicking the title does not close me. Click somewhere else to close me.
+    </Collapse.Content>,
+  ],
+}
+export const ToggleWithClick = Template.bind({})
+ToggleWithClick.args = {
+  focusOpens: false,
+  blurCloses: false,
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Click me to show/hide content
+    </Collapse.Title>,
+    <Collapse.Content>Focus/blur does nothing to me</Collapse.Content>,
+  ],
+}
+
+export const ToggleWithFocusOrClick = Template.bind({})
+ToggleWithFocusOrClick.args = {
+  blurCloses: true,
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Click or focus/blur me to show/hide content
+    </Collapse.Title>,
+    <Collapse.Content>
+      Clicking the title again, or anywhere else closes me
+    </Collapse.Content>,
+  ],
+}
+
+export const WithBorderAndBackgroundColor = Template.bind({})
+WithBorderAndBackgroundColor.args = {
+  className: 'border border-base-300 bg-base-100 rounded-box',
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Click or Focus me to see content
+    </Collapse.Title>,
+    <Collapse.Content>
+      Notice that only clicking the title again will close, while focusing still
+      opens it. Collapses are customizable like that.
+    </Collapse.Content>,
+  ],
+}
+
+export const WithArrowIcon = Template.bind({})
+WithArrowIcon.args = {
+  icon: 'arrow',
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Focus me to see content
+    </Collapse.Title>,
+    <Collapse.Content>This is some content</Collapse.Content>,
+  ],
+}
+
+export const WithPlusMinusIcon = Template.bind({})
+WithPlusMinusIcon.args = {
+  icon: 'plus',
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      Focus me to see content
+    </Collapse.Title>,
+    <Collapse.Content>This is some content</Collapse.Content>,
+  ],
+}
+WithPlusMinusIcon.storyName = 'With Arrow Plus/Minus Icon'
+
+export const WithCustomIcon: Story<CollapseProps> = (args) => {
+  const [isOpen, setIsOpen] = useState(args.open)
+
   return (
-    <Collapse {...args}>
+    <Collapse
+      open={isOpen}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+      icon={
+        <Swap
+          active={isOpen}
+          onClick={() => console.log('test')}
+          onElement={
+            <svg
+              className="fill-current"
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 512 512"
+            >
+              <polygon points="400 145.49 366.51 112 256 222.51 145.49 112 112 145.49 222.51 256 112 366.51 145.49 400 256 289.49 366.51 400 400 366.51 289.49 256 400 145.49" />
+            </svg>
+          }
+          offElement={
+            <svg
+              className="fill-current"
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 512 512"
+            >
+              <path d="M64,384H448V341.33H64Zm0-106.67H448V234.67H64ZM64,128v42.67H448V128Z" />
+            </svg>
+          }
+        />
+      }
+    >
       <Collapse.Title className="text-xl font-medium">
         Focus me to see content
       </Collapse.Title>
-      <Collapse.Content>
-        tabindex="0" attribute is necessary to make the div focusable
-      </Collapse.Content>
+      <Collapse.Content>This is some content</Collapse.Content>
     </Collapse>
   )
 }
 
-export const Default = Template.bind({})
-Default.args = {}
-
-export const Checkbox = Template.bind({})
-Checkbox.args = {
-  checkbox: true,
-}
-
-export const WithBorderAndBackground = Template.bind({})
-WithBorderAndBackground.args = {
-  className: 'border border-base-300 bg-base-100 rounded-box',
-}
-
-export const WithArrow = Template.bind({})
-WithArrow.args = {
-  className: 'border border-base-300 bg-base-100 rounded-box',
-  icon: 'arrow',
-}
-
-export const WithPlusMinus = Template.bind({})
-WithPlusMinus.args = {
-  className: 'border border-base-300 bg-base-100 rounded-box',
-  icon: 'plus',
-}
-
 export const ForceOpen = Template.bind({})
 ForceOpen.args = {
+  forceOpen: true,
   className: 'border border-base-300 bg-base-100 rounded-box',
-  open: true,
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      I have forceOpen prop set to true
+    </Collapse.Title>,
+    <Collapse.Content>You cannot close me</Collapse.Content>,
+  ],
 }
 
 export const ForceClose = Template.bind({})
 ForceClose.args = {
+  forceClose: true,
   className: 'border border-base-300 bg-base-100 rounded-box',
-  open: false,
+  children: [
+    <Collapse.Title className="text-xl font-medium">
+      I have forceClose prop set to true
+    </Collapse.Title>,
+    <Collapse.Content>
+      You cannot open me (not that you will even see this...)
+    </Collapse.Content>,
+  ],
 }
 
 export const CustomColorsWithFocus: Story<CollapseProps> = (args) => {
@@ -65,19 +180,6 @@ export const CustomColorsWithFocus: Story<CollapseProps> = (args) => {
         Focus me to see content
       </Collapse.Title>
       <Collapse.Content className="bg-primary text-primary-content group-focus:bg-secondary group-focus:text-secondary-content">
-        <p>tabindex="0" attribute is necessary to make the div focusable</p>
-      </Collapse.Content>
-    </Collapse>
-  )
-}
-
-export const CustomColorsWithFocusCheckbox: Story<CollapseProps> = (args) => {
-  return (
-    <Collapse {...args} className="group" checkbox>
-      <Collapse.Title className="bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
-        Click me to show/hide content
-      </Collapse.Title>
-      <Collapse.Content className="bg-primary text-primary-content peer-checked:bg-secondary peer-checked:text-secondary-content">
         <p>tabindex="0" attribute is necessary to make the div focusable</p>
       </Collapse.Content>
     </Collapse>

--- a/src/Collapse/Collapse.tsx
+++ b/src/Collapse/Collapse.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import clsx from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -6,40 +6,133 @@ import { IComponentBaseProps } from '../types'
 
 import CollapseTitle from './CollapseTitle'
 import CollapseContent from './CollapseContent'
+import { CollapseContext } from './CollapseContext'
 
 export type CollapseProps = React.HTMLAttributes<HTMLDivElement> &
   IComponentBaseProps & {
-    checkbox?: boolean
-    icon?: 'arrow' | 'plus'
+    icon?: 'arrow' | 'plus' | React.ReactNode
     open?: boolean
+    focusOpens?: boolean
+    blurCloses?: boolean
+    clickOpens?: boolean
+    clickCloses?: boolean
+    forceOpen?: boolean
+    forceClose?: boolean
+    tabIndex?: number
+    onOpen?: () => void
+    onClose?: () => void
   }
 
 const Collapse = React.forwardRef<HTMLDivElement, CollapseProps>(
   (
-    { children, checkbox, icon, open, dataTheme, className, ...props },
+    {
+      children,
+      icon,
+      open,
+      forceOpen,
+      forceClose,
+      tabIndex = 0,
+      clickOpens = true,
+      clickCloses = true,
+      focusOpens = true,
+      blurCloses = false,
+      dataTheme,
+      className,
+      onOpen,
+      onClose,
+      ...props
+    },
     ref
   ): JSX.Element => {
+    if (forceOpen && forceClose) {
+      throw new Error(
+        'Collapse component cannot have both forceOpen and forceClose props set to true.'
+      )
+    }
+
+    // Create ref or use provided ref
+    const elRef = React.useRef<HTMLDivElement>(
+      (ref as React.MutableRefObject<HTMLDivElement>)?.current
+    )
+
+    const [stateIsOpen, setStateIsOpen] = useState(
+      !forceClose && (forceOpen || open)
+    )
+
+    const handleFocus = () => {
+      if (focusOpens) {
+        setOpen()
+      }
+    }
+
+    const handleBlur = () => {
+      if (blurCloses) {
+        setClosed()
+      }
+    }
+
+    const handleClick: React.MouseEventHandler = () => {
+      if (stateIsOpen && clickCloses) {
+        setClosed()
+      } else if (!stateIsOpen && clickOpens) {
+        setOpen()
+      }
+    }
+
+    const setOpen = () => {
+      if (!forceClose && !stateIsOpen) {
+        setStateIsOpen(true)
+        onOpen && onOpen()
+
+        elRef.current?.focus()
+      }
+    }
+
+    const setClosed = () => {
+      if (!forceOpen && stateIsOpen) {
+        setStateIsOpen(false)
+        onClose && onClose()
+      }
+    }
+
+    // Prevent bug where a click also causes a focus, and opens and immediately shuts
+    // Focus is added in handleClick above
+    const handleMouseDown: React.MouseEventHandler = (e) => {
+      e.preventDefault()
+    }
+
     const classes = twMerge(
       'collapse',
       className,
-      clsx({
-        [`collapse-${icon}`]: icon,
-        'collapse-open': open === true,
-        'collapse-close': open === false,
-      })
+      clsx(
+        typeof icon === 'string' && `collapse-${icon}`,
+        stateIsOpen ? 'collapse-open' : 'collapse-close'
+      )
     )
 
     return (
-      <div
-        {...props}
-        ref={ref}
-        tabIndex={0}
-        data-theme={dataTheme}
-        className={classes}
+      <CollapseContext.Provider
+        value={{
+          setOpen,
+          setClosed,
+          isOpen: stateIsOpen,
+          onClick: handleClick,
+          ...(typeof icon !== 'string' && { customIcon: icon }),
+        }}
       >
-        {checkbox && <input type="checkbox" className="peer" />}
-        {children}
-      </div>
+        <div
+          {...props}
+          data-theme={dataTheme}
+          className={classes}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onMouseDown={handleMouseDown}
+          tabIndex={tabIndex}
+          ref={elRef}
+        >
+          {children}
+        </div>
+      </CollapseContext.Provider>
     )
   }
 )

--- a/src/Collapse/CollapseContent.tsx
+++ b/src/Collapse/CollapseContent.tsx
@@ -1,23 +1,29 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { IComponentBaseProps } from '../types'
+import { CollapseContext } from './CollapseContext'
 
 export type CollapseContentProps = React.HTMLAttributes<HTMLDivElement> &
   IComponentBaseProps
 
-const CollapseContent = ({
-  children,
-  className,
-  ...props
-}: CollapseContentProps): JSX.Element => {
-  const classes = twMerge('collapse-content', className)
+const CollapseContent = React.forwardRef<HTMLDivElement, CollapseContentProps>(
+  ({ children, className, ...props }, ref): JSX.Element => {
+    const classes = twMerge('collapse-content', className)
 
-  return (
-    <div {...props} className={classes}>
-      {children}
-    </div>
-  )
-}
+    const handleClick: React.MouseEventHandler = (e) => {
+      if (e.target === e.currentTarget) {
+        e.stopPropagation()
+        e.preventDefault()
+      }
+    }
+
+    return (
+      <div {...props} onClick={handleClick} className={classes} ref={ref}>
+        {children}
+      </div>
+    )
+  }
+)
 
 export default CollapseContent

--- a/src/Collapse/CollapseContext.tsx
+++ b/src/Collapse/CollapseContext.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export interface CollapseContextInterface {
+  isOpen?: boolean
+  onClick: React.MouseEventHandler
+  customIcon?: React.ReactNode
+  setOpen: () => void
+  setClosed: () => void
+}
+
+export const CollapseContext =
+  React.createContext<CollapseContextInterface | null>(null)

--- a/src/Collapse/CollapseTitle.tsx
+++ b/src/Collapse/CollapseTitle.tsx
@@ -1,23 +1,38 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { IComponentBaseProps } from '../types'
+import { CollapseContext } from './CollapseContext'
 
 export type CollapseTitleProps = React.HTMLAttributes<HTMLDivElement> &
   IComponentBaseProps
 
-const CollapseTitle = ({
-  children,
-  className,
-  ...props
-}: CollapseTitleProps): JSX.Element => {
-  const classes = twMerge('collapse-title', className)
+const CollapseTitle = React.forwardRef<HTMLDivElement, CollapseTitleProps>(
+  ({ children, className, ...props }, ref): JSX.Element => {
+    const classes = twMerge('collapse-title', 'text-xl font-medium', className)
+    const { onClick, customIcon } = useContext(CollapseContext)!
 
-  return (
-    <div {...props} className={classes}>
-      {children}
-    </div>
-  )
-}
+    const handleClick: React.MouseEventHandler = (e) => {
+      if (e.target === e.currentTarget) {
+        e.stopPropagation()
+        e.preventDefault()
+        onClick(e)
+      }
+    }
+
+    return (
+      <div {...props} className={classes} onClick={handleClick} ref={ref}>
+        {customIcon ? (
+          <div className="flex flex-row gap-2">
+            <div className="flex-1">{children}</div>
+            {customIcon}
+          </div>
+        ) : (
+          children
+        )}
+      </div>
+    )
+  }
+)
 
 export default CollapseTitle

--- a/src/Collapse/useCollapseContext.ts
+++ b/src/Collapse/useCollapseContext.ts
@@ -1,0 +1,6 @@
+import React, { useContext } from 'react'
+import { CollapseContext } from './CollapseContext'
+
+export const useCollapseContext = () => {
+  return useContext(CollapseContext)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export type CarouselProps = TCarouselProps
 // Data Display > Collapse
 export { default as Collapse } from './Collapse'
 import { CollapseProps as TCollapseProps } from './Collapse'
+export { useCollapseContext } from './Collapse/useCollapseContext'
 export type CollapseProps = TCollapseProps
 
 // Data Display > Countdown


### PR DESCRIPTION
This is just an idea... These changes allow controlling the collapse component easily with react/js. If we like this, we could apply similar changes to dropdown and others.

Collapse changes:
 - added CollapseContext
 - added useCollapseContext hook (wrapper for useContext(CollapseContext)
 - added forwardRef
 - collapse title has 'text-xl font-medium' by default, can be overwritten by className
 - new props:
    - forceOpen?: boolean
    - forceClose?: boolean
    - focusOpens?: boolean, default: true
    - blurCloses?: boolean, default: false
    - clickOpens?: boolean, default: true
    - clickCloses?: boolean, default: true
    - tabIndex?: number, default: 0
    - onOpen?: () => void
    - onClose?: () => void
 - changed props:
    - icon?: 'arrow' | 'plus' | ReactNode
        - if reactNode, render inside of title with a flex