### PR TITLE
fix: button typing for button/anchors, styling

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -101,3 +101,19 @@ export const Icons: Story<ButtonProps> = (args) => {
     </div>
   )
 }
+
+export const AsHref: Story<ButtonProps> = (args) => {
+  return (
+    <div className="flex gap-x-2">
+      <Button
+        {...args}
+        onClick={() => alert('See, I have an onClick event and no href.')}
+      >
+        I'm a {`<button>`}
+      </Button>
+      <Button {...args} href="https://google.com" target="_blank">
+        I'm an {`<a>`}
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
Fixes:

- Added conditional types so typing is correct for a button or anchor, depending on if href is passed
- Since anchor tags cannot have a disabled attribute, we fake the disabled psueo-class with some additional login in twMerge
- Button can have a target now, meaning Buttons with href can open in new tab/etc...