### PR TITLE
Update Input.tsx

### DIFF
--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -26,6 +26,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       color,
       dataTheme,
       className,
+      type,
       ...props
     },
     ref
@@ -45,7 +46,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       <input
         {...props}
         ref={ref}
-        type="text"
+        type={type}
         value={value}
         placeholder={placeholder}
         data-theme={dataTheme}


### PR DESCRIPTION
This change addresses the feature requested in #101 where the IDE presents a `type` attribute for `Input`, however whenever an Input is rendered, its `type` attribute will always be `text`.

Further recommendations would be to implement a custom type where a limited selection of "types" may be selected for input
i.e.
```ts
type: 'date' | 'email' | 'file' | 'image' | 'month' | 'pattern' | 'password' |  'number' | 'tel' | 'text
```

The point being her would be to remove types like `checkbox` and `button` from the list of selectable "inputs" since they're already covered by other components.