### PR TITLE
Enable forwarding refs to DropdownItem

### DIFF
--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 
-export type DropdownItemProps = React.LiHTMLAttributes<HTMLLIElement> & {
-  href?: string
-}
+export type DropdownItemProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
 
-const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>(
-  ({ children, href, ...props }, ref) => {
+const DropdownItem = React.forwardRef<HTMLAnchorElement, DropdownItemProps>(
+  ({ className, ...props }, ref) => {
     return (
-      <li role={href ? 'link' : undefined} {...props} ref={ref}>
-        {href ? <a href={href}>{children}</a> : <>{children}</>}
+      <li className={className}>
+        <a ref={ref} {...props}></a>
       </li>
     )
   }

--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 
-export type DropdownItemProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
-
-const DropdownItem = ({ className, ...props }: DropdownItemProps) => {
-  return (
-    <li className={className}>
-      <a {...props} />
-    </li>
-  )
+export type DropdownItemProps = React.LiHTMLAttributes<HTMLLIElement> & {
+  href?: string;
 }
 
-export default DropdownItem
+const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>(({ children, href, ...props }, ref) => {
+  return (
+    <li role={href ? "link" : undefined} {...props} ref={ref}>
+      {href ? <a href={href}>{children}</a> : <>{children}</>}
+    </li>
+  )
+});
+
+export default DropdownItem;

--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
 
 export type DropdownItemProps = React.LiHTMLAttributes<HTMLLIElement> & {
-  href?: string;
+  href?: string
 }
 
-const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>(({ children, href, ...props }, ref) => {
-  return (
-    <li role={href ? "link" : undefined} {...props} ref={ref}>
-      {href ? <a href={href}>{children}</a> : <>{children}</>}
-    </li>
-  )
-});
+const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>(
+  ({ children, href, ...props }, ref) => {
+    return (
+      <li role={href ? 'link' : undefined} {...props} ref={ref}>
+        {href ? <a href={href}>{children}</a> : <>{children}</>}
+      </li>
+    )
+  }
+)
 
-export default DropdownItem;
+export default DropdownItem


### PR DESCRIPTION
I wanted to wrap the DropdownItem component with the Next.js next/link component, but I couldn't because it does not support forwarding refs. So I improved it.

```tsx
<Dropdown.Menu>
    {items.map((item) => (
        <Link key={item.href} href={item.href} passHref>
            <DropdownItem>{item.title}</DropdownItem>
        </Link>
    ))}
</Dropdown.Menu>
```
(Sorry for my poor English...)