### PR TITLE
feat: allow setting an initial theme value via optional useTheme argument

### DIFF
--- a/src/Theme/Theme.stories.tsx
+++ b/src/Theme/Theme.stories.tsx
@@ -43,6 +43,22 @@ export const Default: Story<ThemeProps> = (args) => {
 }
 Default.args = {}
 
+export const WithInitialValue: Story<ThemeProps> = (args) => {
+  const { theme, setTheme } = useTheme('corporate')
+
+  return (
+    <div className="flex flex-wrap gap-4">
+      <ThemeItem
+        dataTheme={theme}
+        role="button"
+        aria-label="Theme select"
+        tabIndex={0}
+      />
+    </div>
+  )
+}
+WithInitialValue.args = {}
+
 export const NestedThemes: Story<ThemeProps> = (args) => {
   const { theme, setTheme } = useTheme()
 

--- a/src/Theme/useTheme.ts
+++ b/src/Theme/useTheme.ts
@@ -1,7 +1,15 @@
-import { useContext } from 'react'
+import { useContext, useEffect } from 'react'
+import { DataTheme } from '../types'
 import { ThemeContext } from './ThemeContext'
 
-export const useTheme = () => {
-  const context = useContext(ThemeContext)
-  return { theme: context.theme, setTheme: context.setTheme }
+export const useTheme = (value?: DataTheme) => {
+  const { theme, setTheme } = useContext(ThemeContext)
+
+  useEffect(() => {
+    if (value && theme !== value) {
+      setTheme(value)
+    }
+  }, [value])
+
+  return { theme, setTheme }
 }


### PR DESCRIPTION
useTheme now takes an optional parameter for the initial value. This is useful as it allows hook chaining.

For example, a user could have a hook/function that reads the end-user's preferred theme from storage, and passes it to the useTheme hook.

A rough example: 
```
const storedTheme = useConfig('theme')
const {theme, setTheme} = useTheme(storedTheme)
```