### PR TITLE
Missing react-daisy white list in tailwind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To prevent TailwindCSS from purging your styles, add the following line to your 
 
 ```js
 module.exports = {
-  content: ['node_modules/daisyui/dist/**/*.js'],
+  content: ['node_modules/daisyui/dist/**/*.js', 'node_modules/react-daisyui/dist/**/*.js'],
   plugins: [require('daisyui')],
 }
 ```


### PR DESCRIPTION
I was trying to use the `Avatar` component, but it didn't render properly, `ring` and a few other class names were missing.
Adding the react-daisy content fixed the issue, so I believe this should be noted in the docs