### PR TITLE
Fixes "Could not find a declaration file for module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "exports": {
     "import": "./dist/react-daisyui.modern.js",
     "require": "./dist/react-daisyui.cjs",
-    "default": "./dist/react-daisyui.modern.js"
+    "default": "./dist/react-daisyui.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "main": "./dist/react-daisyui.cjs",
   "module": "./dist/react-daisyui.esm.js",


### PR DESCRIPTION
Fixes https://github.com/daisyui/react-daisyui/issues/197

Typings are not referenced correctly when react-daisyui is used from a project using TypeScript with ESM.

I found this solution by looking at another TS repo that had the same issue: https://github.com/typeorm/typeorm/pull/9097

