### PR TITLE
Fix the Table components not passing the 'key' prop to children of lists

### DIFF
--- a/src/Table/TableFooter.tsx
+++ b/src/Table/TableFooter.tsx
@@ -13,8 +13,8 @@ const TableFooter = React.forwardRef<HTMLTableSectionElement, TableFooterProps>(
     return (
       <tfoot {...props} ref={ref}>
         <tr>
-          {children?.map((child) => {
-            return <th>{child}</th>
+          {children?.map((child, i) => {
+            return <th key={i}>{child}</th>
           })}
         </tr>
       </tfoot>

--- a/src/Table/TableHead.tsx
+++ b/src/Table/TableHead.tsx
@@ -10,8 +10,8 @@ const TableHead = React.forwardRef<HTMLTableSectionElement, TableHeadProps>(
     return (
       <thead {...props} ref={ref}>
         <tr>
-          {children?.map((child) => {
-            return <th>{child}</th>
+          {children?.map((child, i) => {
+            return <th key={i}>{child}</th>
           })}
         </tr>
       </thead>

--- a/src/Table/TableRow.tsx
+++ b/src/Table/TableRow.tsx
@@ -24,7 +24,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
     return (
       <tr {...props} className={classes} ref={ref}>
         {children?.map((child, i) => 
-          i < 1 ? <th>{child}</th> : <td>{child}</td>
+          i < 1 ? <th key={i}>{child}</th> : <td key={i}>{child}</td>
         )}
       </tr>
     )


### PR DESCRIPTION
Component: Table
Issue: Table component not passing 'key' prop to children of lists #204 

Fix the Table components not passing the 'key' prop to children of lists