### PR TITLE
Checkbox: Remove checked and defaultChecked props and leave it to default props

### DIFF
--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -26,8 +26,6 @@ export type CheckboxProps = Omit<
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     {
-      checked,
-      defaultChecked = false,
       color,
       size,
       indeterminate,
@@ -66,8 +64,6 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         {...props}
         ref={checkboxRef}
         type="checkbox"
-        checked={checked}
-        defaultChecked={defaultChecked}
         data-theme={dataTheme}
         className={classes}
       />


### PR DESCRIPTION
component: Checkbox
issue: Due to defaultChecked is always set internally, if checked is also set, warning is thrown (#213)

Removed both the `checked` and `defaultChecked` props and leave it to the HtmlInputElement props to be split on the component.
This resolves the console warning when providing `checked` prop because `defaultChecked` is not longer set by default.