### PR TITLE
Select: Fix Select component warning and update examples

### DIFF
--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -20,8 +20,12 @@ export default {
 export const Default: Story<SelectProps<string>> = (args) => {
   return (
     <div className="flex w-full component-preview p-4 items-center justify-center gap-2 font-sans">
-      <Select {...args}>
-        <Option value={undefined} disabled selected>
+      <Select 
+        initialValue={'default'}
+        onChange={console.log}
+        {...args}
+      >
+        <Option value={'default'} disabled>
           Pick your favorite Simpson
         </Option>
         <Option value={'Homer'}>Homer</Option>
@@ -42,11 +46,15 @@ export const FormControlAndLabels: Story<SelectProps<string>> = (args) => {
           <span className="label-text">Pick the best fantasy franchise</span>
           <span className="label-text-alt">Alt label</span>
         </label>
-        <Select {...args}>
-          <Option value={undefined} disabled selected>
+        <Select
+          initialValue={'default'}
+          onChange={console.log}
+          {...args}
+        >
+          <Option value={'default'} disabled>
             Pick one
           </Option>
-          <Option value="Start Wars">Star Wars</Option>
+          <Option value="Star Wars">Star Wars</Option>
           <Option value="Harry Potter">Harry Potter</Option>
           <Option value="Lord of the Rings">Lord of the Rings</Option>
           <Option value="Planet of the Apes">Planet of the Apes</Option>

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -69,12 +69,9 @@ const SelectInner = <T extends string | number | undefined>(
         setSelectedValue(e.currentTarget.value as T)
         onChange && onChange(e.currentTarget.value as T)
       }}
+      value={selectedValue}
     >
-      {children.map((child) => {
-        return cloneElement(child, {
-          selectedValue: selectedValue,
-        })
-      })}
+      {children}
     </select>
   )
 }

--- a/src/Select/SelectOption.tsx
+++ b/src/Select/SelectOption.tsx
@@ -4,18 +4,19 @@ export type SelectOptionProps<T> = Omit<
   React.OptionHTMLAttributes<HTMLOptionElement>,
   'value'
 > & {
-  selectedValue?: T
   value: T
 }
 
 const SelectOption = <T extends string | number | undefined>({
-  selectedValue,
   value,
   children,
   ...props
 }: SelectOptionProps<T>): JSX.Element => {
   return (
-    <option {...props} value={value} selected={value === selectedValue}>
+    <option 
+      {...props} 
+      value={value}
+    >
       {children}
     </option>
   )


### PR DESCRIPTION
Component: Select
Issue: #223

The Select component was using a mix between [controlled](https://reactjs.org/docs/forms.html#controlled-components) and [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html).

This PR resolves the warning webpack gave because of the above and brings the storybook examples inline.

__**This is not a breaking change, previous behaviour is unchanged and will still work as expected**__