### PR TITLE
fix: handle Tabs state externally

### DIFF
--- a/src/Tabs/Tabs.stories.tsx
+++ b/src/Tabs/Tabs.stories.tsx
@@ -17,8 +17,9 @@ export default {
 } as Meta
 
 const Template: Story<TabsProps<number>> = (args) => {
+  const [tabValue, setTabValue] = React.useState(0)
   return (
-    <Tabs {...args}>
+    <Tabs {...args} value={tabValue} onChange={setTabValue}>
       <Tab value={0}>Tab 1</Tab>
       <Tab value={1}>Tab 2</Tab>
       <Tab value={2}>Tab 3</Tab>

--- a/src/Tabs/Tabs.test.tsx
+++ b/src/Tabs/Tabs.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/extend-expect'
+
+import { render, fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import Tabs from './'
+
+describe('Tabs', () => {
+  const tabLabel1 = 'one'
+  const tabLabel2 = 'two'
+  const tabValue1 = 1
+  const tabValue2 = 2
+
+  it('Should render tabs', () => {
+    render(
+      <Tabs>
+        <Tabs.Tab value={tabValue1}>{tabLabel1}</Tabs.Tab>
+        <Tabs.Tab value={tabValue2}>{tabLabel2}</Tabs.Tab>
+      </Tabs>
+    )
+    expect(screen.getByRole('tablist')).toBeInTheDocument()
+  })
+
+  it('Should render tab labels', () => {
+    render(
+      <Tabs>
+        <Tabs.Tab value={tabValue1}>{tabLabel1}</Tabs.Tab>
+        <Tabs.Tab value={tabValue2}>{tabLabel2}</Tabs.Tab>
+      </Tabs>
+    )
+    expect(screen.getByText(tabLabel1)).toBeInTheDocument()
+    expect(screen.getByText(tabLabel2)).toBeInTheDocument()
+  })
+
+  it('Should call handler on tab click', async () => {
+    const mockHandler = jest.fn()
+    render(
+      <Tabs onChange={mockHandler}>
+        <Tabs.Tab value={tabValue1}>{tabLabel1}</Tabs.Tab>
+        <Tabs.Tab value={tabValue2}>{tabLabel2}</Tabs.Tab>
+      </Tabs>
+    )
+    const tab = screen.getByText(tabLabel1)
+    await userEvent.click(tab)
+    expect(mockHandler).toHaveBeenCalled()
+    expect(mockHandler).toBeCalledWith(tabValue1)
+  })
+})

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ReactElement, useState } from 'react'
+import React, { cloneElement, ReactElement } from 'react'
 import clsx from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -6,7 +6,10 @@ import { IComponentBaseProps, ComponentSize } from '../types'
 
 import Tab, { TabProps } from './Tab'
 
-export type TabsProps<T> = Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> &
+export type TabsProps<T> = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange'
+> &
   IComponentBaseProps & {
     children: ReactElement<TabProps<T>>[]
     value?: T
@@ -30,8 +33,6 @@ const TabsInner = <T extends string | number | undefined>(
   }: TabsProps<T>,
   ref?: React.ForwardedRef<T>
 ): JSX.Element => {
-  const [activeValue, setActiveValue] = useState<T | undefined>(value)
-
   const classes = twMerge(
     'tabs',
     className,
@@ -42,19 +43,19 @@ const TabsInner = <T extends string | number | undefined>(
 
   return (
     <div
-      ref={ref as React.ForwardedRef<HTMLDivElement>} 
+      ref={ref as React.ForwardedRef<HTMLDivElement>}
       role="tablist"
       {...props}
       data-theme={dataTheme}
       className={classes}
     >
-      {children.map((child) => {
+      {children.map((child, index) => {
         return cloneElement(child, {
+          key: child.props.value,
           variant,
           size,
-          activeValue: activeValue,
+          activeValue: value,
           onClick: (value: T) => {
-            setActiveValue(value)
             onChange && onChange(value)
           },
         })


### PR DESCRIPTION
- Tabs state is now controlled externally by passing `value` and `onChange` props to the `<Tabs>` component.
- added tests for `<Tabs />` component (#137)

resolves #220

