### PR TITLE
fix: Link (<a/> tag) is vulnerable when use `target="_blank"`

### DIFF
--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -26,6 +26,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(
 
     return (
       <a
+        rel="noopener noreferrer"
         {...props}
         href={href}
         data-theme={dataTheme}


### PR DESCRIPTION
According to https://stackoverflow.com/a/17711167/5104886, `opener` & `refererrer` can be vulnerable when use `target="_blank"`, disabling them by default would be a bit more secured if using older Chrome or Safari.


Newer Chrome and Safari had fixed this vulnerability:
- Chrome enabled noopener behavior in release 88.
- Safari also enabled this in release 68.

https://stackoverflow.com/a/66373987/5104886