### PR TITLE
Fix: Tooltip positions

### DIFF
--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -36,7 +36,10 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       clsx({
         'tooltip-open': open,
         [`tooltip-${color}`]: color,
-        [`tooltip-${position}`]: position,
+        'tooltip-top': position === 'top',
+        'tooltip-bottom': position === 'bottom',
+        'tooltip-left': position === 'left',
+        'tooltip-right': position === 'right',
       })
     )
 


### PR DESCRIPTION
Replaced the string interpolation so that tailwind can capture the classnames correctly, fixes #234 