### PR TITLE
Add test setup file for jest-dom

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,14 +1,16 @@
 module.exports = {
-    roots: ["<rootDir>/src"],
-    testEnvironment: 'jsdom',
-    transform: {
-      "^.+\\.tsx?$": "ts-jest",
-    },
-    preset: "ts-jest",
-    testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
-    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-    moduleNameMapper: {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
-    },
-};
+  roots: ['<rootDir>/src'],
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  preset: 'ts-jest',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+      '<rootDir>/__mocks__/fileMock.js',
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
+  },
+  setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
+}

--- a/src/Button/Button.test.tsx
+++ b/src/Button/Button.test.tsx
@@ -1,39 +1,34 @@
-import '@testing-library/jest-dom'
-import '@testing-library/jest-dom/extend-expect'
-
-import * as React from 'react'
-import { render, fireEvent, screen } from '@testing-library/react'
-
+import { fireEvent, render, screen } from '@testing-library/react'
 import Button from './'
 
 describe('Button', () => {
   it('Should render button', () => {
-    const { getByRole } = render(<Button>test</Button>)
-    expect(getByRole('button')).toBeInTheDocument()
+    render(<Button>test</Button>)
+    expect(screen.getByRole('button')).toBeInTheDocument()
   })
 
   it('Should call onClick once per click event', () => {
     const mockType = jest.fn()
-    const { getByRole } = render(<Button onClick={mockType}>test</Button>)
-    fireEvent.click(getByRole('button'))
+    render(<Button onClick={mockType}>test</Button>)
+    fireEvent.click(screen.getByRole('button'))
     expect(mockType).toHaveBeenCalledTimes(1)
   })
 
   it('Should not call onClick from click event if disabled', () => {
     const mockType = jest.fn()
-    const { getByRole } = render(
+    render(
       <Button onClick={mockType} disabled>
         test
       </Button>
     )
-    fireEvent.click(getByRole('button'))
+    fireEvent.click(screen.getByRole('button'))
     expect(mockType).toHaveBeenCalledTimes(0)
   })
 
   it('Renders an anchor tag when an href exists', () => {
-    const { getByRole } = render(<Button href="/home">Home</Button>)
+    render(<Button href="/home">Home</Button>)
 
-    expect(getByRole('link')).toBeTruthy()
-    expect(getByRole('link')).toHaveAttribute('href', '/home')
+    expect(screen.getByRole('link')).toBeTruthy()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/home')
   })
 })

--- a/src/Footer/Footer.test.tsx
+++ b/src/Footer/Footer.test.tsx
@@ -1,6 +1,3 @@
-import '@testing-library/jest-dom'
-import '@testing-library/jest-dom/extend-expect'
-
 import { render, screen } from '@testing-library/react'
 
 import Footer from '.'
@@ -12,36 +9,40 @@ describe('Footer', () => {
   it('Should render Footer title', () => {
     render(
       <Footer className="p-10 bg-neutral text-neutral-content">
-      <div>
-        <Footer.Title>{footerTitle}</Footer.Title>
-      </div>
-    </Footer>
+        <div>
+          <Footer.Title>{footerTitle}</Footer.Title>
+        </div>
+      </Footer>
     )
     expect(screen.getByText(footerTitle)).toBeInTheDocument()
   })
 
   it('Footer title have className "p-10 bg-neutral text-neutral-content"', () => {
-    const {container} = render(
+    const { container } = render(
       <Footer className="p-10 bg-neutral text-neutral-content">
-      <div>
-        <Footer.Title>{footerTitle}</Footer.Title>
-      </div>
-    </Footer>
+        <div>
+          <Footer.Title>{footerTitle}</Footer.Title>
+        </div>
+      </Footer>
     )
-    const titleClassName = container.getElementsByClassName('p-10 bg-neutral text-neutral-content')
+    const titleClassName = container.getElementsByClassName(
+      'p-10 bg-neutral text-neutral-content'
+    )
     expect(titleClassName).toBeTruthy()
   })
 
   it('Footer links have className "link link-hover"', () => {
-    const {container} = render(
+    const { container } = render(
       <Footer className="p-10 bg-neutral text-neutral-content">
-      <div>
-        <Footer.Title>{footerTitle}</Footer.Title>
-        {linkList.map((links) => (
-          <a key= {links} className="link link-hover">{links}</a>
-        ))}
-      </div>
-    </Footer>
+        <div>
+          <Footer.Title>{footerTitle}</Footer.Title>
+          {linkList.map((links) => (
+            <a key={links} className="link link-hover">
+              {links}
+            </a>
+          ))}
+        </div>
+      </Footer>
     )
     expect(screen.getByText(linkList[0])).toBeInTheDocument()
     const quantityLinks = container.getElementsByClassName('link link-hover')
@@ -49,15 +50,17 @@ describe('Footer', () => {
   })
 
   it('Should render Footer link list', () => {
-    const {container} = render(
+    const { container } = render(
       <Footer className="p-10 bg-neutral text-neutral-content">
-      <div>
-        <Footer.Title>{footerTitle}</Footer.Title>
-        {linkList.map((links) => (
-          <a key= {links} className="link link-hover">{links}</a>
-        ))}
-      </div>
-    </Footer>
+        <div>
+          <Footer.Title>{footerTitle}</Footer.Title>
+          {linkList.map((links) => (
+            <a key={links} className="link link-hover">
+              {links}
+            </a>
+          ))}
+        </div>
+      </Footer>
     )
     const linksClassName = container.getElementsByClassName('link link-hover')
     expect(linksClassName).toBeTruthy()

--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -1,9 +1,8 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import Modal from './'
 import Button from '../Button'
-import '@testing-library/jest-dom'
-import React from 'react'
-import userEvent from '@testing-library/user-event'
 
 const TestModal = ({ state }: { state: boolean }) => {
   const [open, setOpen] = React.useState(state)

--- a/src/Radio/Radio.test.tsx
+++ b/src/Radio/Radio.test.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import Form from '../Form'
-import Radio from './Radio'
-import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
+import Radio from './Radio'
+import Form from '../Form'
 import Button from '../Button'
 
 const TestRadio2 = () => {

--- a/src/Range/Range.test.tsx
+++ b/src/Range/Range.test.tsx
@@ -1,8 +1,5 @@
-import '@testing-library/jest-dom'
-import React from 'react'
-
-import Range from './Range'
 import { render, screen } from '@testing-library/react'
+import Range from './Range'
 
 describe('Range', () => {
   it('should not render with invalid step', () => {

--- a/src/Tabs/Tabs.test.tsx
+++ b/src/Tabs/Tabs.test.tsx
@@ -1,6 +1,3 @@
-import '@testing-library/jest-dom'
-import '@testing-library/jest-dom/extend-expect'
-
 import { render, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 

--- a/src/Toggle/Toggle.test.tsx
+++ b/src/Toggle/Toggle.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import Toggle from './Toggle'
-import '@testing-library/jest-dom'
-import Form from '../Form'
 import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import Toggle from './Toggle'
+import Form from '../Form'
 
 const ToggleTest = () => {
   const [toggleState, setToggleState] = useState(false)

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxFactory": "",
-    "jsxFragmentFactory": "",
+    "jsxFragmentFactory": ""
   },
-  "include": ["./src"],
-  "exclude": ["./src/**/*.stories.tsx"],
+  "include": ["./src", "test-setup.ts"],
+  "exclude": ["./src/**/*.stories.tsx"]
 }


### PR DESCRIPTION
I was starting to add some unit tests per #137 and noticed an opportunity to add a test setup file. This avoids having to import `jest-dom` in every test file. I also updated some tests to use `screen` which is considered a [best practice for RTL tests](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen). Hopefully I'm not overstepping here but I saw this as a good opportunity to streamline the tests.