### PR TITLE
dropdown toggle default button type

### DIFF
--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -29,6 +29,7 @@ const DropdownToggle = ({
     <label tabIndex={0} className={className} {...props}>
       {button ? (
         <Button
+          type='button'
           dataTheme={dataTheme}
           color={color}
           size={size}


### PR DESCRIPTION
Hello everyone, usually I'd create an issue for something like this, but since the change is trivial I thought I'd file a PR instead, I do not think the default button type of "submit" makes sense for dropdown toggles, you do not want it to submit a form and I don't think there'd be an use case where someone may need to set it to anything other than "button", this is why I didn't add a prop.