### PR TITLE
fix: Removed generic on Select

### DIFF
--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -22,10 +22,10 @@ export const Default: Story<SelectProps<string>> = (args) => {
 
   return (
     <div className="flex w-full component-preview p-4 items-center justify-center gap-2 font-sans">
-      <Select 
+      <Select
         {...args}
         value={value}
-        onChange={setValue}
+        onChange={(event) => setValue(event.target.value)}
       >
         <Option value={'default'} disabled>
           Pick your favorite Simpson
@@ -48,11 +48,7 @@ export const FormControlAndLabels: Story<SelectProps<string>> = (args) => {
           <span className="label-text">Pick the best fantasy franchise</span>
           <span className="label-text-alt">Alt label</span>
         </label>
-        <Select
-          defaultValue={'default'}
-          onChange={console.log}
-          {...args}
-        >
+        <Select defaultValue={'default'} onChange={console.log} {...args}>
           <Option value={'default'} disabled>
             Pick one
           </Option>

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -6,33 +6,25 @@ import { IComponentBaseProps, ComponentColor, ComponentSize } from '../types'
 
 import SelectOption, { SelectOptionProps } from './SelectOption'
 
-export type SelectOption<T> = {
-  value: T
-  label: string
-}
-
-export type SelectProps<T> = Omit<
+export type SelectProps = Omit<
   React.SelectHTMLAttributes<HTMLSelectElement>,
-  'onChange' | 'value' | 'size' | 'color'
+  'size' | 'color'
 > &
   IComponentBaseProps & {
-    children: ReactElement<SelectOptionProps<T>>[]
-    value?: T
-    onChange?: (value: T) => void
+    children: ReactElement<SelectOptionProps>[]
+
     size?: ComponentSize
     color?: ComponentColor
     bordered?: boolean
     borderOffset?: boolean
   }
 
-const SelectInner = <T extends string | number | undefined>(
-  props: SelectProps<T>,
+const SelectInner = (
+  props: SelectProps,
   ref: React.ForwardedRef<HTMLSelectElement>
 ): JSX.Element => {
   const {
     children,
-    value,
-    onChange,
     size,
     color,
     bordered = true,
@@ -54,22 +46,11 @@ const SelectInner = <T extends string | number | undefined>(
   )
 
   return (
-    <select
-      {...rest}
-      ref={ref}
-      data-theme={dataTheme}
-      className={classes}
-      onChange={(e) => onChange?.(e.currentTarget.value as T)}
-      value={value}
-    >
+    <select {...rest} ref={ref} data-theme={dataTheme} className={classes}>
       {children}
     </select>
   )
 }
 
-// Make forwardRef work with generic component
-const Select = React.forwardRef(SelectInner) as <T>(
-  props: SelectProps<T> & { ref?: React.ForwardedRef<HTMLSelectElement> }
-) => ReturnType<typeof SelectInner>
-
+const Select = React.forwardRef(SelectInner)
 export default Object.assign(Select, { Option: SelectOption })

--- a/src/Select/SelectOption.tsx
+++ b/src/Select/SelectOption.tsx
@@ -1,22 +1,13 @@
 import React from 'react'
 
-export type SelectOptionProps<T> = Omit<
-  React.OptionHTMLAttributes<HTMLOptionElement>,
-  'value'
-> & {
-  value: T
-}
+export type SelectOptionProps = React.OptionHTMLAttributes<HTMLOptionElement>
 
-const SelectOption = <T extends string | number | undefined>({
-  value,
+const SelectOption = ({
   children,
   ...props
-}: SelectOptionProps<T>): JSX.Element => {
+}: SelectOptionProps): JSX.Element => {
   return (
-    <option 
-      {...props} 
-      value={value}
-    >
+    <option {...props}>
       {children}
     </option>
   )


### PR DESCRIPTION
In favor to be compliant with the standard API I removed the generic support on Select.
I got your idea why you introduced that but the problem with the current implementation is that your custom onChange also does not really work. 

event.target.value is always a string, the type does not change just by casting it to T.

Also for Select ,all of the sudden the standard way of using the select component does not work anymore and I think this could lead to problems and confusion. 

I also assume that this would solve 

https://github.com/daisyui/react-daisyui/issues/264
https://github.com/daisyui/react-daisyui/issues/272

Which needs to be confirmed.

Let me know what you think


Best
Sahin