### PR TITLE
fix(Kbd): incorrect size class name

### DIFF
--- a/src/Kbd/Kbd.stories.tsx
+++ b/src/Kbd/Kbd.stories.tsx
@@ -23,9 +23,7 @@ export const InText: Story<KbdProps> = (args) => {
     </div>
   )
 }
-InText.args = {
-  size: 'sm',
-}
+InText.args = {}
 
 export const KeyCombination: Story<KbdProps> = (args) => {
   return (

--- a/src/Kbd/Kbd.tsx
+++ b/src/Kbd/Kbd.tsx
@@ -15,10 +15,10 @@ const Kbd = forwardRef<HTMLElement, KbdProps>(
       'kbd',
       className,
       clsx({
-        'bd-lg': size === 'lg',
-        'bd-md': size === 'md',
-        'bd-sm': size === 'sm',
-        'bd-xs': size === 'xs',
+        'kbd-lg': size === 'lg',
+        'kbd-md': size === 'md',
+        'kbd-sm': size === 'sm',
+        'kbd-xs': size === 'xs',
       })
     )
 


### PR DESCRIPTION
Adresses #331

Also removed default args for stories, they were too small with `sm` and  `md` is already the default.