### PR TITLE
refactor(DropdownItem): make wrapping of children with anchor tag optional

### DIFF
--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
-export type DropdownItemProps = React.AnchorHTMLAttributes<HTMLAnchorElement>
+export type DropdownItemProps =
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & { anchor?: boolean }
 
 const DropdownItem = React.forwardRef<HTMLAnchorElement, DropdownItemProps>(
-  ({ className, ...props }, ref) => {
+  ({ anchor = true, ...props }, ref) => {
     return (
-      <li className={className} role="menuitem">
-        <a ref={ref} {...props}></a>
+      <li role="menuitem">
+        {anchor ? <a ref={ref} {...props}></a> : props.children}
       </li>
     )
   }

--- a/src/Dropdown/DropdownItem.tsx
+++ b/src/Dropdown/DropdownItem.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
-export type DropdownItemProps =
-  React.AnchorHTMLAttributes<HTMLAnchorElement> & { anchor?: boolean }
+type Anchor = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  anchor?: true
+}
+
+type NoAnchor = Pick<Anchor, 'children'> & { anchor?: false }
+
+export type DropdownItemProps = Anchor | NoAnchor
 
 const DropdownItem = React.forwardRef<HTMLAnchorElement, DropdownItemProps>(
   ({ anchor = true, ...props }, ref) => {


### PR DESCRIPTION
I believe this solves #144 and also, allows the usage of the new updates introduced to daisyUI v3 related to Menu (eg: [Menu with active item](https://daisyui.com/components/menu/#menu-with-active-item)). The default behavior is the case where the `children` is wrapped in an anchor tag so it doesn't cause a breaking change.