### PR TITLE
Modal form change  proposal

### DIFF
--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -91,7 +91,9 @@ export const CustomWidth: Story<ModalProps> = (args) => {
           Press ESC key or click the button below to close
         </Modal.Body>
         <Modal.Actions>
-          <Button>Close</Button>
+          <form method="dialog">
+            <Button>Close</Button>
+          </form>
         </Modal.Actions>
       </Modal>
     </div>
@@ -111,7 +113,9 @@ export const UseDialogHook: Story<ModalProps> = (args) => {
         <Modal.Header className="font-bold">Hello!</Modal.Header>
         <Modal.Body>This modal works with useDialog hook!</Modal.Body>
         <Modal.Actions>
-          <Button>Close</Button>
+          <form method="dialog">
+            <Button>Close</Button>
+          </form>
         </Modal.Actions>
       </Dialog>
     </div>

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -23,7 +23,9 @@ export const Default: Story<ModalProps> = (args) => {
           Press ESC key or click the button below to close
         </Modal.Body>
         <Modal.Actions>
-          <Button>Close</Button>
+          <form method="dialog">
+            <Button>Close</Button>
+          </form>
         </Modal.Actions>
       </Modal>
     </div>
@@ -58,14 +60,16 @@ export const CloseButton: Story<ModalProps> = (args) => {
     <div className="font-sans">
       <Button onClick={handleShow}>Open Modal</Button>
       <Modal {...args} ref={ref}>
-        <Button
-          size="sm"
-          color="ghost"
-          shape="circle"
-          className="absolute right-2 top-2"
-        >
-          x
-        </Button>
+        <form method="dialog">
+          <Button
+            size="sm"
+            color="ghost"
+            shape="circle"
+            className="absolute right-2 top-2"
+          >
+            x
+          </Button>
+        </form>
         <Modal.Header className="font-bold">Hello!</Modal.Header>
         <Modal.Body>Press ESC key or click on X button to close</Modal.Body>
       </Modal>

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -42,9 +42,9 @@ const Modal = forwardRef<HTMLDialogElement, ModalProps>(
         className={containerClasses}
         ref={ref}
       >
-        <form method="dialog" data-theme={dataTheme} className={bodyClasses}>
+        <div data-theme={dataTheme} className={bodyClasses}>
           {children}
-        </form>
+        </div>
         {backdrop && (
           <form method="dialog" className="modal-backdrop">
             <button>close</button>


### PR DESCRIPTION
Right now it's not possible to add a form inside a Modal as it throws this error: 
`Warning: validateDOMNesting(...): <form> cannot appear as a descendant of <form>. `

Clicking on any button inside the modal closes it as well, which is not always intended.

This PR proposes to change this behavior, if a user want to close the modal he can always use:
 ```
<form method="dialog">
            <Button>Close</Button>
 </form>
```
or
`  <Button onClick={toggleModal}>Close me</Button>
`
inside the modal.

This is a proposal change for this opened issue: https://github.com/daisyui/react-daisyui/issues/415
