### PR TITLE
Range component ticks fix

### DIFF
--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -39,16 +39,18 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
       })
     )
 
-    displayTicks = displayTicks ?? (step !== undefined);
-    ticksStep = ticksStep ?? Number(step);
+    const calculatedDisplayTicks = displayTicks ?? (step !== undefined);
+    const calculatedStep = step !== undefined ? Number(step) : 1; // default value per HTML standard
+    const calculatedTicksStep = ticksStep ?? calculatedStep;
 
     const isNumeric = (n: any): n is number =>
       !isNaN(parseFloat(n)) && isFinite(n)
 
-    const numSteps = useMemo(() => {
-      const safeStep = Math.max(1, Number(step))
-      return Math.ceil(100 / safeStep) ?? 1
-    }, [props.max, step])
+    const numTicks = useMemo(() => {
+      const min = props.min !== undefined ? Number(props.min) : 0; // default value per HTML standard
+      const max = props.max !== undefined ? Number(props.max) : 100; // default value per HTML standard
+      return Math.ceil((max - min) / calculatedTicksStep) + 1;
+    }, [props.min, props.max, ticksStep])
 
     return (
       <>
@@ -62,7 +64,7 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
         />
         {isNumeric(step) && (
           <div className="w-full flex justify-between text-xs px-2">
-            {[...Array(numSteps + 1)].map((_, i) => {
+            {[...Array(numTicks)].map((_, i) => {
               return <span key={i}>|</span>
             })}
           </div>

--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -15,10 +15,12 @@ export type RangeProps = Omit<
   IComponentBaseProps & {
     color?: ComponentColor
     size?: ComponentSize
+    displayTicks?: boolean
+    ticksStep: number
   }
 
 const Range = forwardRef<HTMLInputElement, RangeProps>(
-  ({ color, size, step, dataTheme, className, ...props }, ref): JSX.Element => {
+  ({ color, size, step, displayTicks, ticksStep, dataTheme, className, ...props }, ref): JSX.Element => {
     const classes = twMerge(
       'range',
       className,

--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -39,6 +39,9 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
       })
     )
 
+    displayTicks = displayTicks ?? (step !== undefined);
+    ticksStep = ticksStep ?? Number(step);
+
     const isNumeric = (n: any): n is number =>
       !isNaN(parseFloat(n)) && isFinite(n)
 

--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -42,13 +42,10 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
     const calculatedDisplayTicks = displayTicks ?? (step !== undefined);
     const calculatedStep = step !== undefined ? Number(step) : 1; // default value per HTML standard
     const calculatedTicksStep = ticksStep ?? calculatedStep;
-
-    const isNumeric = (n: any): n is number =>
-      !isNaN(parseFloat(n)) && isFinite(n)
+    const min = props.min !== undefined ? Number(props.min) : 0; // default value per HTML standard
+    const max = props.max !== undefined ? Number(props.max) : 100; // default value per HTML standard
 
     const numTicks = useMemo(() => {
-      const min = props.min !== undefined ? Number(props.min) : 0; // default value per HTML standard
-      const max = props.max !== undefined ? Number(props.max) : 100; // default value per HTML standard
       return Math.ceil((max - min) / calculatedTicksStep) + 1;
     }, [props.min, props.max, ticksStep])
 
@@ -62,7 +59,7 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
           data-theme={dataTheme}
           className={classes}
         />
-        {isNumeric(step) && (
+        {calculatedDisplayTicks && (
           <div className="w-full flex justify-between text-xs px-2">
             {[...Array(numTicks)].map((_, i) => {
               return <span key={i}>|</span>

--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -45,10 +45,8 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
     const min = props.min !== undefined ? Number(props.min) : 0; // default value per HTML standard
     const max = props.max !== undefined ? Number(props.max) : 100; // default value per HTML standard
 
-    const numTicks = useMemo(() => {
-      // use Math.max to solve multiple issues with negative numbers throwing errors
-      return Math.max(Math.ceil((max - min) / calculatedTicksStep), 1) + 1;
-    }, [props.min, props.max, ticksStep])
+    // use Math.max to solve multiple issues with negative numbers throwing errors
+    const numTicks = Math.max(Math.ceil((max - min) / calculatedTicksStep), 1) + 1;
 
     return (
       <>

--- a/src/Range/Range.tsx
+++ b/src/Range/Range.tsx
@@ -46,7 +46,8 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
     const max = props.max !== undefined ? Number(props.max) : 100; // default value per HTML standard
 
     const numTicks = useMemo(() => {
-      return Math.ceil((max - min) / calculatedTicksStep) + 1;
+      // use Math.max to solve multiple issues with negative numbers throwing errors
+      return Math.max(Math.ceil((max - min) / calculatedTicksStep), 1) + 1;
     }, [props.min, props.max, ticksStep])
 
     return (


### PR DESCRIPTION
This PR fixes #437.

In a nutshell:
* The problem - the `Range` component ticks math is wrong, only takes into account range [0, 100] and no step sizes < 1. Also, ticks are always displayed when `step` is provided, whether you want to or not.
* The suggested fix - add `displayTicks` and `ticksStep` parameters to control when to display ticks, and what the ticks step size should be, which can now be different than `step` (before, they were the same by design). Also, take into account `props.min` and `props.max` to allow for the range the user intended in the ticks.