### PR TITLE
feat: Added ariaHidden to Modal component Props.

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -14,11 +14,21 @@ export type ModalProps = React.HTMLAttributes<HTMLDialogElement> &
     open?: boolean
     responsive?: boolean
     backdrop?: boolean
+    ariaHidden?: boolean
   }
 
 const Modal = forwardRef<HTMLDialogElement, ModalProps>(
   (
-    { children, open, responsive, backdrop, dataTheme, className, ...props },
+    {
+      children,
+      open,
+      responsive,
+      backdrop,
+      ariaHidden,
+      dataTheme,
+      className,
+      ...props
+    },
     ref
   ): JSX.Element => {
     const containerClasses = twMerge(
@@ -29,13 +39,14 @@ const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       })
     )
 
+    ariaHidden = ariaHidden ?? !open
     const bodyClasses = twMerge('modal-box', className)
 
     return (
       <dialog
         {...props}
         aria-label="Modal"
-        aria-hidden={!open}
+        aria-hidden={ariaHidden}
         open={open}
         aria-modal={open}
         data-theme={dataTheme}


### PR DESCRIPTION
If elements that can receive focus are to be included in Modal's children, they must be `aria-hidden="false"`. However, there is no option to specify aria-hidden, so I would like to add it.

If using `props.backdrop`, the user would set `props.open=undefined`. Therefore, the ability to specify aria-hidden independent of the value of `props.open` would be beneficial.

The addition of this feature does not affect existing operation. When `props.ariaHidden` is undefined, the behavior is the same as before.

[mdn](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) states the following:

```
aria-hidden="true" should not be used on elements that can receive focus. Additionally, since this attribute is inherited by an element's children, it should not be added onto the parent or ancestor of a focusable element.
```