### PR TITLE
fix(Modal): fixed Props type to use DialogHTMLAttributes

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import { IComponentBaseProps } from '../types'
 import ModalActions from './ModalActions'
 import ModalBody from './ModalBody'
 import ModalHeader from './ModalHeader'
-import ModalLegacy, { ModalProps as ModalLegacyProps } from './ModalLegacy'
+import ModalLegacy from './ModalLegacy'
 
 export type ModalProps = React.DialogHTMLAttributes<HTMLDialogElement> &
   IComponentBaseProps & {

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -9,7 +9,7 @@ import ModalBody from './ModalBody'
 import ModalHeader from './ModalHeader'
 import ModalLegacy, { ModalProps as ModalLegacyProps } from './ModalLegacy'
 
-export type ModalProps = React.HTMLAttributes<HTMLDialogElement> &
+export type ModalProps = React.DialogHTMLAttributes<HTMLDialogElement> &
   IComponentBaseProps & {
     open?: boolean
     responsive?: boolean

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -14,11 +14,21 @@ export type ModalProps = React.HTMLAttributes<HTMLDialogElement> &
     open?: boolean
     responsive?: boolean
     backdrop?: boolean
+    ariaHidden?: boolean
   }
 
 const Modal = forwardRef<HTMLDialogElement, ModalProps>(
   (
-    { children, open, responsive, backdrop, dataTheme, className, ...props },
+    {
+      children,
+      open,
+      responsive,
+      backdrop,
+      ariaHidden,
+      dataTheme,
+      className,
+      ...props
+    },
     ref
   ): JSX.Element => {
     const containerClasses = twMerge(
@@ -29,13 +39,14 @@ const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       })
     )
 
+    ariaHidden = ariaHidden ?? !open
     const bodyClasses = twMerge('modal-box', className)
 
     return (
       <dialog
         {...props}
         aria-label="Modal"
-        aria-hidden={!open}
+        aria-hidden={ariaHidden}
         open={open}
         aria-modal={open}
         data-theme={dataTheme}


### PR DESCRIPTION
DialogHTMLAttributes should be used instead of HTMLAttributes.

This prevents type errors when using onClose.