### PR TITLE
More flexible Table.Head/Footer with [noCell] prop for better pinCols support

### DIFF
--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -493,43 +493,12 @@ Xs.args = {
   size: 'xs',
 }
 
+// set of 50 columns with data to help demo scrolling and pinned headers
+const colCount = 50
 const tableData: { headers: string[]; row: string[]; footers: string[] } = {
-  headers: [
-    'header1',
-    'header2',
-    'header3',
-    'header4',
-    'header5',
-    'header6',
-    'header7',
-    'header8',
-    'header9',
-    'header10',
-  ],
-  row: [
-    'data1',
-    'data2',
-    'data3',
-    'data4',
-    'data5',
-    'data6',
-    'data7',
-    'data8',
-    'data9',
-    'data10',
-  ],
-  footers: [
-    'footer1',
-    'footer2',
-    'footer3',
-    'footer4',
-    'footer5',
-    'footer6',
-    'footer7',
-    'footer8',
-    'footer9',
-    'footer10',
-  ],
+  headers: new Array(colCount).fill('header').map((value, i) => value + i),
+  row: new Array(colCount).fill('data').map((value, i) => value + i),
+  footers: new Array(colCount).fill('footer').map((value, i) => value + i),
 }
 
 const renderTableItem = (v, i, renderCell = true) => {
@@ -537,7 +506,8 @@ const renderTableItem = (v, i, renderCell = true) => {
     return <div>{v}</div>
   }
 
-  return <td>{v}</td>
+  // render every 5th cell as a th, which get pinned as users scroll
+  return i % 5 === 0 ? <th>{v}</th> : <td>{v}</td>
 }
 
 const renderHeaders = (noCell) =>
@@ -573,4 +543,5 @@ PinnedRowsOrColsNoCell.args = {
   noCell: true,
   pinRows: true,
   pinCols: true,
+  zebra: true,
 }

--- a/src/Table/Table.stories.tsx
+++ b/src/Table/Table.stories.tsx
@@ -1,11 +1,11 @@
+import { Meta, StoryFn as Story } from '@storybook/react'
 import React from 'react'
-import { StoryFn as Story, Meta } from '@storybook/react'
 
 import Table, { TableProps } from '.'
-import Checkbox from '../Checkbox'
-import Mask from '../Mask'
 import Badge from '../Badge'
 import Button from '../Button'
+import Checkbox from '../Checkbox'
+import Mask from '../Mask'
 
 export default {
   title: 'Data Display/Table',
@@ -493,504 +493,84 @@ Xs.args = {
   size: 'xs',
 }
 
-export const PinnedRows: Story<TableProps> = (args) => {
-  return (
-    <div className="overflow-x-auto h-96">
-      <Table {...args}>
-        <thead>
-          <tr>
-            <th>A</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Ant-Man</td>
-          </tr>
-          <tr>
-            <td>Aquaman</td>
-          </tr>
-          <tr>
-            <td>Asterix</td>
-          </tr>
-          <tr>
-            <td>The Atom</td>
-          </tr>
-          <tr>
-            <td>The Avengers</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>B</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Batgirl</td>
-          </tr>
-          <tr>
-            <td>Batman</td>
-          </tr>
-          <tr>
-            <td>Batwoman</td>
-          </tr>
-          <tr>
-            <td>Black Canary</td>
-          </tr>
-          <tr>
-            <td>Black Panther</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>C</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Captain America</td>
-          </tr>
-          <tr>
-            <td>Captain Marvel</td>
-          </tr>
-          <tr>
-            <td>Catwoman</td>
-          </tr>
-          <tr>
-            <td>Conan the Barbarian</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>D</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Daredevil</td>
-          </tr>
-          <tr>
-            <td>The Defenders</td>
-          </tr>
-          <tr>
-            <td>Doc Savage</td>
-          </tr>
-          <tr>
-            <td>Doctor Strange</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>E</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Elektra</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>F</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Fantastic Four</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>G</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Ghost Rider</td>
-          </tr>
-          <tr>
-            <td>Green Arrow</td>
-          </tr>
-          <tr>
-            <td>Green Lantern</td>
-          </tr>
-          <tr>
-            <td>Guardians of the Galaxy</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>H</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Hawkeye</td>
-          </tr>
-          <tr>
-            <td>Hellboy</td>
-          </tr>
-          <tr>
-            <td>Incredible Hulk</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>I</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Iron Fist</td>
-          </tr>
-          <tr>
-            <td>Iron Man</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>M</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Marvelman</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>R</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Robin</td>
-          </tr>
-          <tr>
-            <td>The Rocketeer</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>S</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>The Shadow</td>
-          </tr>
-          <tr>
-            <td>Spider-Man</td>
-          </tr>
-          <tr>
-            <td>Sub-Mariner</td>
-          </tr>
-          <tr>
-            <td>Supergirl</td>
-          </tr>
-          <tr>
-            <td>Superman</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>T</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Teenage Mutant Ninja Turtles</td>
-          </tr>
-          <tr>
-            <td>Thor</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>W</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>The Wasp</td>
-          </tr>
-          <tr>
-            <td>Watchmen</td>
-          </tr>
-          <tr>
-            <td>Wolverine</td>
-          </tr>
-          <tr>
-            <td>Wonder Woman</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>X</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>X-Men</td>
-          </tr>
-        </tbody>
-        <thead>
-          <tr>
-            <th>Z</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Zatanna</td>
-          </tr>
-          <tr>
-            <td>Zatara</td>
-          </tr>
-        </tbody>
-      </Table>
-    </div>
-  )
-}
-PinnedRows.args = {
-  pinRows: true,
+const tableData: { headers: string[]; row: string[]; footers: string[] } = {
+  headers: [
+    'header1',
+    'header2',
+    'header3',
+    'header4',
+    'header5',
+    'header6',
+    'header7',
+    'header8',
+    'header9',
+    'header10',
+  ],
+  row: [
+    'data1',
+    'data2',
+    'data3',
+    'data4',
+    'data5',
+    'data6',
+    'data7',
+    'data8',
+    'data9',
+    'data10',
+  ],
+  footers: [
+    'footer1',
+    'footer2',
+    'footer3',
+    'footer4',
+    'footer5',
+    'footer6',
+    'footer7',
+    'footer8',
+    'footer9',
+    'footer10',
+  ],
 }
 
-export const PinnedRowsAndPinnedCols: Story<TableProps> = (args) => {
+const renderTableItem = (v, i, renderCell = true) => {
+  if (renderCell) {
+    return <div>{v}</div>
+  }
+
+  return <td>{v}</td>
+}
+
+const renderHeaders = (noCell) =>
+  tableData.headers.map((v, i) => renderTableItem(v, i, noCell))
+const renderRow = (noCell) =>
+  tableData.row.map((v, i) => renderTableItem(v, i, noCell))
+const renderFooter = (noCell) =>
+  tableData.footers.map((v, i) => renderTableItem(v, i, noCell))
+
+interface NoCellStoryProps extends TableProps {
+  noCell?: boolean
+}
+
+export const PinnedRowsOrColsNoCell: Story<NoCellStoryProps> = ({
+  noCell,
+  ...args
+}) => {
+  const renderRows = new Array(10)
+    .fill('')
+    .map(() => <Table.Row noCell={noCell}>{renderRow(!noCell)}</Table.Row>)
+
   return (
-    <div className="overflow-x-auto h-96 w-96">
+    <div className="overflow-x-auto max-w-lg max-h-80">
       <Table {...args}>
-        <thead>
-          <tr>
-            <th></th>
-            <td>Name</td>
-            <td>Job</td>
-            <td>company</td>
-            <td>location</td>
-            <td>Last Login</td>
-            <td>Favorite Color</td>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>1</th>
-            <td>Cy Ganderton</td>
-            <td>Quality Control Specialist</td>
-            <td>Littel, Schaden and Vandervort</td>
-            <td>Canada</td>
-            <td>12/16/2020</td>
-            <td>Blue</td>
-            <th>1</th>
-          </tr>
-          <tr>
-            <th>2</th>
-            <td>Hart Hagerty</td>
-            <td>Desktop Support Technician</td>
-            <td>Zemlak, Daniel and Leannon</td>
-            <td>United States</td>
-            <td>12/5/2020</td>
-            <td>Purple</td>
-            <th>2</th>
-          </tr>
-          <tr>
-            <th>3</th>
-            <td>Brice Swyre</td>
-            <td>Tax Accountant</td>
-            <td>Carroll Group</td>
-            <td>China</td>
-            <td>8/15/2020</td>
-            <td>Red</td>
-            <th>3</th>
-          </tr>
-          <tr>
-            <th>4</th>
-            <td>Marjy Ferencz</td>
-            <td>Office Assistant I</td>
-            <td>Rowe-Schoen</td>
-            <td>Russia</td>
-            <td>3/25/2021</td>
-            <td>Crimson</td>
-            <th>4</th>
-          </tr>
-          <tr>
-            <th>5</th>
-            <td>Yancy Tear</td>
-            <td>Community Outreach Specialist</td>
-            <td>Wyman-Ledner</td>
-            <td>Brazil</td>
-            <td>5/22/2020</td>
-            <td>Indigo</td>
-            <th>5</th>
-          </tr>
-          <tr>
-            <th>6</th>
-            <td>Irma Vasilik</td>
-            <td>Editor</td>
-            <td>Wiza, Bins and Emard</td>
-            <td>Venezuela</td>
-            <td>12/8/2020</td>
-            <td>Purple</td>
-            <th>6</th>
-          </tr>
-          <tr>
-            <th>7</th>
-            <td>Meghann Durtnal</td>
-            <td>Staff Accountant IV</td>
-            <td>Schuster-Schimmel</td>
-            <td>Philippines</td>
-            <td>2/17/2021</td>
-            <td>Yellow</td>
-            <th>7</th>
-          </tr>
-          <tr>
-            <th>8</th>
-            <td>Sammy Seston</td>
-            <td>Accountant I</td>
-            <td>O'Hara, Welch and Keebler</td>
-            <td>Indonesia</td>
-            <td>5/23/2020</td>
-            <td>Crimson</td>
-            <th>8</th>
-          </tr>
-          <tr>
-            <th>9</th>
-            <td>Lesya Tinham</td>
-            <td>Safety Technician IV</td>
-            <td>Turner-Kuhlman</td>
-            <td>Philippines</td>
-            <td>2/21/2021</td>
-            <td>Maroon</td>
-            <th>9</th>
-          </tr>
-          <tr>
-            <th>10</th>
-            <td>Zaneta Tewkesbury</td>
-            <td>VP Marketing</td>
-            <td>Sauer LLC</td>
-            <td>Chad</td>
-            <td>6/23/2020</td>
-            <td>Green</td>
-            <th>10</th>
-          </tr>
-          <tr>
-            <th>11</th>
-            <td>Andy Tipple</td>
-            <td>Librarian</td>
-            <td>Hilpert Group</td>
-            <td>Poland</td>
-            <td>7/9/2020</td>
-            <td>Indigo</td>
-            <th>11</th>
-          </tr>
-          <tr>
-            <th>12</th>
-            <td>Sophi Biles</td>
-            <td>Recruiting Manager</td>
-            <td>Gutmann Inc</td>
-            <td>Indonesia</td>
-            <td>2/12/2021</td>
-            <td>Maroon</td>
-            <th>12</th>
-          </tr>
-          <tr>
-            <th>13</th>
-            <td>Florida Garces</td>
-            <td>Web Developer IV</td>
-            <td>Gaylord, Pacocha and Baumbach</td>
-            <td>Poland</td>
-            <td>5/31/2020</td>
-            <td>Purple</td>
-            <th>13</th>
-          </tr>
-          <tr>
-            <th>14</th>
-            <td>Maribeth Popping</td>
-            <td>Analyst Programmer</td>
-            <td>Deckow-Pouros</td>
-            <td>Portugal</td>
-            <td>4/27/2021</td>
-            <td>Aquamarine</td>
-            <th>14</th>
-          </tr>
-          <tr>
-            <th>15</th>
-            <td>Moritz Dryburgh</td>
-            <td>Dental Hygienist</td>
-            <td>Schiller, Cole and Hackett</td>
-            <td>Sri Lanka</td>
-            <td>8/8/2020</td>
-            <td>Crimson</td>
-            <th>15</th>
-          </tr>
-          <tr>
-            <th>16</th>
-            <td>Reid Semiras</td>
-            <td>Teacher</td>
-            <td>Sporer, Sipes and Rogahn</td>
-            <td>Poland</td>
-            <td>7/30/2020</td>
-            <td>Green</td>
-            <th>16</th>
-          </tr>
-          <tr>
-            <th>17</th>
-            <td>Alec Lethby</td>
-            <td>Teacher</td>
-            <td>Reichel, Glover and Hamill</td>
-            <td>China</td>
-            <td>2/28/2021</td>
-            <td>Khaki</td>
-            <th>17</th>
-          </tr>
-          <tr>
-            <th>18</th>
-            <td>Aland Wilber</td>
-            <td>Quality Control Specialist</td>
-            <td>Kshlerin, Rogahn and Swaniawski</td>
-            <td>Czech Republic</td>
-            <td>9/29/2020</td>
-            <td>Purple</td>
-            <th>18</th>
-          </tr>
-          <tr>
-            <th>19</th>
-            <td>Teddie Duerden</td>
-            <td>Staff Accountant III</td>
-            <td>Pouros, Ullrich and Windler</td>
-            <td>France</td>
-            <td>10/27/2020</td>
-            <td>Aquamarine</td>
-            <th>19</th>
-          </tr>
-          <tr>
-            <th>20</th>
-            <td>Lorelei Blackstone</td>
-            <td>Data Coordinator</td>
-            <td>Witting, Kutch and Greenfelder</td>
-            <td>Kazakhstan</td>
-            <td>6/3/2020</td>
-            <td>Red</td>
-            <th>20</th>
-          </tr>
-        </tbody>
-        <tfoot>
-          <tr>
-            <th></th>
-            <td>Name</td>
-            <td>Job</td>
-            <td>company</td>
-            <td>location</td>
-            <td>Last Login</td>
-            <td>Favorite Color</td>
-            <th></th>
-          </tr>
-        </tfoot>
+        <Table.Head noCell={noCell}>{renderHeaders(!noCell)}</Table.Head>
+        <Table.Body>{renderRows}</Table.Body>
+        <Table.Footer noCell={noCell}>{renderFooter(!noCell)}</Table.Footer>
       </Table>
     </div>
   )
 }
-PinnedRowsAndPinnedCols.args = {
-  size: 'xs',
+PinnedRowsOrColsNoCell.args = {
+  noCell: true,
   pinRows: true,
   pinCols: true,
 }

--- a/src/Table/Table.test.tsx
+++ b/src/Table/Table.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { render } from '@testing-library/react'
+import React from 'react'
 import Table from './'
 
 describe('Table', () => {
@@ -47,5 +47,36 @@ describe('Table', () => {
   it('Should apply pinRows prop', () => {
     const { container } = render(<Table pinRows />)
     expect(container.firstChild).toHaveClass('table-pin-rows')
+  })
+
+  const tableComponents: [string, React.ElementType][] = [
+    ['Table.Head', Table.Head],
+    ['Table.Row', Table.Row],
+    ['Table.Footer', Table.Footer],
+  ]
+  describe.each(tableComponents)('asd', (componentName, TableComponent) => {
+    it(`${componentName}: Should render th for the first child and td tags for subsequent children when noCell is false`, () => {
+      const { container } = render(
+        <TableComponent>
+          <span>1</span>
+          <span>2</span>
+          <span>3</span>
+        </TableComponent>
+      )
+      expect(container.querySelectorAll('th').length).toEqual(1)
+      expect(container.querySelectorAll('td').length).toEqual(2)
+    })
+
+    it(`${componentName}: Should render th for the first child and td tags for subsequent children when noCell is false`, () => {
+      const { container } = render(
+        <TableComponent>
+          <span>1</span>
+          <span>2</span>
+          <span>3</span>
+        </TableComponent>
+      )
+      expect(container.querySelectorAll('th').length).toEqual(1)
+      expect(container.querySelectorAll('td').length).toEqual(2)
+    })
   })
 })

--- a/src/Table/TableFooter.tsx
+++ b/src/Table/TableFooter.tsx
@@ -6,17 +6,20 @@ export type TableFooterProps =
   React.TableHTMLAttributes<HTMLTableSectionElement> &
     IComponentBaseProps & {
       children?: ReactElement[]
+      noCell?: boolean // don't wrap children in th/td, should pass children as th/tds manually
     }
 
 const TableFooter = React.forwardRef<HTMLTableSectionElement, TableFooterProps>(
-  ({ children, ...props }, ref): JSX.Element => {
+  ({ children, noCell = false, ...props }, ref): JSX.Element => {
+    const renderChildren = noCell
+      ? children
+      : children?.map((child, i) =>
+          i < 1 ? <th key={i}>{child}</th> : <td key={i}>{child}</td>
+        )
+
     return (
       <tfoot {...props} ref={ref}>
-        <tr>
-          {children?.map((child, i) => {
-            return <th key={i}>{child}</th>
-          })}
-        </tr>
+        <tr>{renderChildren}</tr>
       </tfoot>
     )
   }

--- a/src/Table/TableHead.tsx
+++ b/src/Table/TableHead.tsx
@@ -3,17 +3,20 @@ import React, { ReactNode } from 'react'
 export type TableHeadProps =
   React.TableHTMLAttributes<HTMLTableSectionElement> & {
     children?: ReactNode[]
+    noCell?: boolean // don't wrap children in th/td, should pass children as th/tds manually
   }
 
 const TableHead = React.forwardRef<HTMLTableSectionElement, TableHeadProps>(
-  ({ children, ...props }, ref): JSX.Element => {
+  ({ children, noCell = false, ...props }, ref): JSX.Element => {
+    const renderChildren = noCell
+      ? children
+      : children?.map((child, i) =>
+          i < 1 ? <th key={i}>{child}</th> : <td key={i}>{child}</td>
+        )
+
     return (
       <thead {...props} ref={ref}>
-        <tr>
-          {children?.map((child, i) => {
-            return <th key={i}>{child}</th>
-          })}
-        </tr>
+        <tr>{renderChildren}</tr>
       </thead>
     )
   }

--- a/src/Table/TableRow.tsx
+++ b/src/Table/TableRow.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement } from 'react'
 import clsx from 'clsx'
+import React, { ReactElement } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import { IComponentBaseProps } from '../types'
@@ -9,10 +9,14 @@ export type TableRowProps = React.TableHTMLAttributes<HTMLTableRowElement> &
     children?: ReactElement[]
     active?: boolean
     hover?: boolean
+    noCell?: boolean // don't wrap children in th/td, should pass children as th/tds manually
   }
 
 const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
-  ({ children, active, hover, className, ...props }, ref): JSX.Element => {
+  (
+    { children, active, hover, noCell = false, className, ...props },
+    ref
+  ): JSX.Element => {
     const classes = twMerge(
       className,
       clsx({
@@ -21,11 +25,15 @@ const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
       })
     )
 
+    const renderChildren = noCell
+      ? children
+      : children?.map((child, i) =>
+          i < 1 ? <th key={i}>{child}</th> : <td key={i}>{child}</td>
+        )
+
     return (
       <tr {...props} className={classes} ref={ref}>
-        {children?.map((child, i) => 
-          i < 1 ? <th key={i}>{child}</th> : <td key={i}>{child}</td>
-        )}
+        {renderChildren}
       </tr>
     )
   }


### PR DESCRIPTION
Addresses #462 

Currently the Table.Head/Body/Row/Footer pattern is very rigid - always wrapping children with th/td tags in Head/Footer. We don't want to break backwards compatibility, so to enable better table customization this PR adds the noCell property to Table.Head, Row and Footer. This prop allows devs to disable internally wrapping th/td tags and pass th/td tags as children manually - but still keep the useful default behaviour.

This is useful because it lets devs pin th tags in a row at any location, not just the first child.

eg.

What you couldn't do but now can with noCell:

```tsx
<Table pinCols>
  <Table.Head noCell>
    <th></th>
    <td></td>
    <td></td>
    <th></th>
    <td></td>
    <td></td>
  </Table.Head>

  <Table.Body>
    <Table.Row noCell>
      <th></th>
      <td></td>
      <td></td>
      <th></th>
      <td></td>
      <td></td>
    </Table.Row>
  </Table.Body>

  <Table.Footer noCell>
    <th></th>
    <td></td>
    <td></td>
    <th></th>
    <td></td>
    <td></td>
  </Table.Footer>
</Table>
```

Also updated tests for Table.Head/Row/Footer to cover noCell cases AND updated the story with a robust example with staggered th tags when noCell is enabled.