### PR TITLE
Dropdown.Toggle accepts all ButtonProps or LabelProps + unstyled prop

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -5,6 +5,7 @@ import Dropdown, { DropdownProps } from '.'
 import Card from '../Card/'
 import Navbar from '../Navbar'
 import Button from '../Button'
+import Badge from '../Badge'
 
 export default {
   title: 'Actions/Dropdown',
@@ -74,6 +75,54 @@ export const InNavbar: Story<DropdownProps> = ({ dataTheme, ...args }) => {
 }
 InNavbar.args = {
   end: true,
+}
+
+export const ButtonToggle: Story<DropdownProps> = (args) => {
+  return (
+    <div className="my-32">
+      <Dropdown {...args}>
+        <Dropdown.Toggle size="sm" variant="outline" color="secondary">
+          Click
+        </Dropdown.Toggle>
+        <Dropdown.Menu className="w-52">
+          <Dropdown.Item>Item 1</Dropdown.Item>
+          <Dropdown.Item>Item 2</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  )
+}
+
+export const LabelToggle: Story<DropdownProps> = (args) => {
+  return (
+    <div className="my-32">
+      <Dropdown {...args}>
+        <Dropdown.Toggle button={false}>Click</Dropdown.Toggle>
+        <Dropdown.Menu className="w-52">
+          <Dropdown.Item>Item 1</Dropdown.Item>
+          <Dropdown.Item>Item 2</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  )
+}
+
+export const UnstyledCustomToggle: Story<DropdownProps> = (args) => {
+  return (
+    <div className="my-32">
+      <Dropdown {...args}>
+        <Dropdown.Toggle unstyled>
+          <Badge color="primary" variant="outline" className="cursor-pointer">
+            Any component can be a toggle, even a {`<Badge>`}!
+          </Badge>
+        </Dropdown.Toggle>
+        <Dropdown.Menu className="w-52">
+          <Dropdown.Item>Item 1</Dropdown.Item>
+          <Dropdown.Item>Item 2</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  )
 }
 
 export const Helper: Story<DropdownProps> = (args) => {

--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -1,11 +1,10 @@
+import { Meta, StoryFn as Story } from '@storybook/react'
 import React from 'react'
-import { StoryFn as Story, Meta } from '@storybook/react'
-
 import Dropdown, { DropdownProps } from '.'
+import Badge from '../Badge'
+import Button from '../Button'
 import Card from '../Card/'
 import Navbar from '../Navbar'
-import Button from '../Button'
-import Badge from '../Badge'
 
 export default {
   title: 'Actions/Dropdown',
@@ -81,7 +80,7 @@ export const ButtonToggle: Story<DropdownProps> = (args) => {
   return (
     <div className="my-32">
       <Dropdown {...args}>
-        <Dropdown.Toggle size="sm" variant="outline" color="secondary">
+        <Dropdown.Toggle size="xl" color="success" variant="dash">
           Click
         </Dropdown.Toggle>
         <Dropdown.Menu className="w-52">

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -34,7 +34,7 @@ describe('Dropdown', () => {
     )
 
     expect(screen.getByRole('listbox')).toHaveClass('custom-dropdown')
-    expect(screen.getByText('Toggle').parentElement).toHaveClass(
+    expect(screen.getByText('Toggle').closest('button')).toHaveClass(
       'custom-toggle'
     )
     expect(screen.getByRole('menu')).toHaveClass('custom-menu')
@@ -74,5 +74,59 @@ describe('Dropdown', () => {
     expect(screen.getByRole('listbox')).toHaveClass('dropdown-end')
     expect(screen.getByRole('listbox')).toHaveClass('dropdown-hover')
     expect(screen.getByRole('listbox')).toHaveClass('dropdown-open')
+  })
+
+  test('Should render a Button when button=true (default)', () => {
+    render(
+      <Dropdown>
+        <Dropdown.Toggle>Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>{DropdownItems}</Dropdown.Menu>
+      </Dropdown>
+    )
+
+    const toggle = screen.getByRole('button', { name: 'Toggle' })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle.tagName).toBe('BUTTON')
+  })
+
+  test('Should render a Button when button=true (explicit)', () => {
+    render(
+      <Dropdown>
+        <Dropdown.Toggle button={true}>Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>{DropdownItems}</Dropdown.Menu>
+      </Dropdown>
+    )
+
+    const toggle = screen.getByRole('button', { name: 'Toggle' })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle.tagName).toBe('BUTTON')
+  })
+
+  test('Should render a Label when button=false', () => {
+    render(
+      <Dropdown>
+        <Dropdown.Toggle button={false}>Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>{DropdownItems}</Dropdown.Menu>
+      </Dropdown>
+    )
+
+    const toggle = screen.getByRole('button', { name: 'Toggle' })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle.tagName).toBe('LABEL')
+  })
+
+  test('Should render a div when unstyled=true', () => {
+    render(
+      <Dropdown>
+        <Dropdown.Toggle unstyled aria-label="Dropdown toggle">
+          Toggle
+        </Dropdown.Toggle>
+        <Dropdown.Menu>{DropdownItems}</Dropdown.Menu>
+      </Dropdown>
+    )
+
+    const toggle = screen.getByRole('button', { name: 'Dropdown toggle' })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle.tagName).toBe('DIV')
   })
 })

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -12,7 +12,10 @@ export type LabelDropdownToggleProps = Omit<LabelProps, 'color'> & {
   unstyled?: false
 }
 
-export type UnstyledDropdownToggleProps = HTMLAttributes<HTMLElement> & {
+export type UnstyledDropdownToggleProps = Omit<
+  HTMLAttributes<HTMLElement>,
+  'color'
+> & {
   button?: false
   unstyled: true
 }

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -1,21 +1,34 @@
-import React, { forwardRef, LabelHTMLAttributes } from 'react'
+import React, { forwardRef, HTMLAttributes } from 'react'
 import Button, { ButtonProps } from '../Button'
 import Label, { LabelProps } from '../Form/Label'
 
 export type ButtonDropdownToggleProps = ButtonProps & {
   button?: true
+  unstyled?: false
 }
 
 export type LabelDropdownToggleProps = LabelProps & {
   button?: false
+  unstyled?: false
 }
 
-export type DropdownToggleProps = React.HTMLAttributes<HTMLElement> &
+export type DropdownToggleProps = HTMLAttributes<HTMLElement> &
   (ButtonDropdownToggleProps | LabelDropdownToggleProps)
 
 const DropdownToggle = forwardRef<HTMLElement, DropdownToggleProps>(
   (props, ref) => {
-    const { button = true, children, ...rest } = props
+    const { button = true, unstyled = false, children, ...rest } = props
+
+    if (unstyled) {
+      return (
+        <div
+          ref={ref as React.Ref<HTMLDivElement>}
+          {...(rest as React.HTMLAttributes<HTMLElement>)}
+        >
+          {children}
+        </div>
+      )
+    }
 
     if (button) {
       return (

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -7,43 +7,44 @@ export type ButtonDropdownToggleProps = ButtonProps & {
   unstyled?: false
 }
 
-export type LabelDropdownToggleProps = LabelProps & {
-  button?: false
+export type LabelDropdownToggleProps = Omit<LabelProps, 'color'> & {
+  button: false
   unstyled?: false
 }
 
-export type DropdownToggleProps = HTMLAttributes<HTMLElement> &
-  (ButtonDropdownToggleProps | LabelDropdownToggleProps)
+export type UnstyledDropdownToggleProps = HTMLAttributes<HTMLElement> & {
+  button?: false
+  unstyled: true
+}
+
+export type DropdownToggleProps =
+  | ButtonDropdownToggleProps
+  | LabelDropdownToggleProps
+  | UnstyledDropdownToggleProps
 
 const DropdownToggle = forwardRef<HTMLElement, DropdownToggleProps>(
   (props, ref) => {
-    const { button = true, unstyled = false, children, ...rest } = props
+    const { button = true, unstyled = false, ...rest } = props
 
     if (unstyled) {
       return (
         <div
           ref={ref as React.Ref<HTMLDivElement>}
+          role="button"
+          tabIndex={0}
           {...(rest as React.HTMLAttributes<HTMLElement>)}
-        >
-          {children}
-        </div>
+        />
       )
-    }
-
-    if (button) {
-      return (
-        <Button ref={ref} type="button" {...(rest as ButtonProps)}>
-          {children}
-        </Button>
-      )
+    } else if (button) {
+      return <Button ref={ref} {...(rest as ButtonDropdownToggleProps)} />
     } else {
       return (
         <Label
           ref={ref as React.Ref<HTMLLabelElement>}
-          {...(rest as LabelProps)}
-        >
-          {children}
-        </Label>
+          role="button"
+          tabIndex={0}
+          {...(rest as LabelDropdownToggleProps)}
+        />
       )
     }
   }

--- a/src/Dropdown/DropdownToggle.tsx
+++ b/src/Dropdown/DropdownToggle.tsx
@@ -1,48 +1,40 @@
-import React, { forwardRef } from 'react'
-
-import { ComponentColor, ComponentSize, IComponentBaseProps } from '../types'
-
+import React, { forwardRef, LabelHTMLAttributes } from 'react'
 import Button, { ButtonProps } from '../Button'
+import Label, { LabelProps } from '../Form/Label'
 
-export type DropdownToggleProps = Omit<
-  React.LabelHTMLAttributes<HTMLLabelElement>,
-  'color'
-> &
-  IComponentBaseProps & {
-    color?: ComponentColor
-    size?: ComponentSize
-    button?: boolean
-    disabled?: boolean
-  }
+export type ButtonDropdownToggleProps = ButtonProps & {
+  button?: true
+}
 
-const DropdownToggle = ({
-  children,
-  color,
-  size,
-  button = true,
-  dataTheme,
-  className,
-  disabled,
-  ...props
-}: DropdownToggleProps) => {
-  return (
-    <label tabIndex={0} className={className} {...props}>
-      {button ? (
-        <Button
-          type="button"
-          dataTheme={dataTheme}
-          color={color}
-          size={size}
-          disabled={disabled}
-        >
+export type LabelDropdownToggleProps = LabelProps & {
+  button?: false
+}
+
+export type DropdownToggleProps = React.HTMLAttributes<HTMLElement> &
+  (ButtonDropdownToggleProps | LabelDropdownToggleProps)
+
+const DropdownToggle = forwardRef<HTMLElement, DropdownToggleProps>(
+  (props, ref) => {
+    const { button = true, children, ...rest } = props
+
+    if (button) {
+      return (
+        <Button ref={ref} type="button" {...(rest as ButtonProps)}>
           {children}
         </Button>
-      ) : (
-        children
-      )}
-    </label>
-  )
-}
+      )
+    } else {
+      return (
+        <Label
+          ref={ref as React.Ref<HTMLLabelElement>}
+          {...(rest as LabelProps)}
+        >
+          {children}
+        </Label>
+      )
+    }
+  }
+)
 
 export type SummaryProps = Omit<ButtonProps, 'tag'>
 export const Summary = forwardRef<HTMLElement, SummaryProps>(


### PR DESCRIPTION
Something that was bothering me - Dropdown.Toggle doesn't accept all ButtonProps but easily could. Caused me to use button={false} and just put my own Button inside of it many times. Added the same support for Label if `button={false}`.

Also added an `unstyled` prop while I was there in case people want to use their own component but still have the Toggle work properly. Only HTMLAttributes<HTMLElement> props are available if `unstyled={true}`

Should be fully backwards compatible

### Demo

https://github.com/user-attachments/assets/c1b6d8cf-b644-4a72-b14d-8aa43fd99543