### PR TITLE
Fix Modal aria hidden warning

### DIFF
--- a/src/Modal/Modal.test.tsx
+++ b/src/Modal/Modal.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Modal from './'
+import React, { useCallback, useRef } from 'react'
 import Button from '../Button'
+import Modal from './'
+import './dialog.mock'
 
 const TestModal = ({ state }: { state: boolean }) => {
   const [open, setOpen] = React.useState(state)
@@ -83,5 +84,70 @@ describe('Modal', () => {
     expect(
       screen.queryByRole('button', { name: 'Do not click me' })
     ).not.toBeInTheDocument()
+  })
+
+  describe('dialog ref handlers', () => {
+    const TestDialogWithHandlers = () => {
+      const ref = useRef<HTMLDialogElement>(null)
+      const handleShow = useCallback(() => {
+        ref.current?.showModal()
+      }, [ref])
+      const handleClose = useCallback(() => {
+        ref.current?.close()
+      }, [ref])
+      return (
+        <div className="font-sans">
+          <Button onClick={handleShow}>Open Modal</Button>
+          <Modal ref={ref}>
+            <Modal.Header className="font-bold">Hello!</Modal.Header>
+            <Modal.Body>
+              Press ESC key or click the button below to close
+            </Modal.Body>
+            <Modal.Actions>
+              <Button onClick={handleClose}>Close</Button>
+            </Modal.Actions>
+          </Modal>
+        </div>
+      )
+    }
+
+    it('should show modal with button', async () => {
+      const user = userEvent.setup()
+      render(<TestDialogWithHandlers />)
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+      const openButton = screen.getByRole('button', { name: 'Open Modal' })
+      expect(openButton).toBeInTheDocument()
+
+      await user.click(openButton)
+
+      const dialog = await screen.findByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+
+      const closeButton = screen.getByRole('button', { name: 'Close' })
+      expect(closeButton).toBeInTheDocument()
+      await user.click(closeButton)
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      })
+    })
+
+    it('should handle cancel event when triggered manually', async () => {
+      const user = userEvent.setup()
+      render(<TestDialogWithHandlers />)
+
+      const openButton = screen.getByRole('button', { name: 'Open Modal' })
+      await user.click(openButton)
+
+      const dialog = await screen.findByRole<HTMLDialogElement>('dialog')
+      expect(dialog).toBeInTheDocument()
+
+      // Manually trigger the cancel event (simulating ESC key)
+      await dialog.triggerCancel()
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,8 +1,7 @@
-import React, { forwardRef, useCallback, useRef } from 'react'
 import clsx from 'clsx'
+import React, { forwardRef, useCallback, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
-
-import { IComponentBaseProps, ComponentPosition } from '../types'
+import { ComponentPosition, IComponentBaseProps } from '../types'
 
 import ModalActions from './ModalActions'
 import ModalBody from './ModalBody'
@@ -40,8 +39,8 @@ const Modal = forwardRef<HTMLDialogElement, ModalProps>(
         'modal-end': position === 'end',
         'modal-start': position === 'start',
         'modal-top': position === 'top',
-        'modal-middle': position === 'middle',
         'modal-bottom': position === 'bottom',
+        'modal-middle': position === undefined,
         'modal-bottom sm:modal-middle': responsive,
       })
     )
@@ -78,18 +77,21 @@ Modal.displayName = 'Modal'
 export type DialogProps = Omit<ModalProps, 'ref'>
 const useDialog = () => {
   const dialogRef = useRef<HTMLDialogElement>(null)
+  const [ariaHidden, setAriaHidden] = useState(true)
 
   const handleShow = useCallback(() => {
     dialogRef.current?.showModal()
+    setAriaHidden(false)
   }, [dialogRef])
 
   const handleHide = useCallback(() => {
     dialogRef.current?.close()
+    setAriaHidden(true)
   }, [dialogRef])
 
   const Dialog = ({ children, ...props }: DialogProps) => {
     return (
-      <Modal {...props} ref={dialogRef}>
+      <Modal {...props} ref={dialogRef} ariaHidden={ariaHidden}>
         {children}
       </Modal>
     )

--- a/src/Modal/dialog.mock.ts
+++ b/src/Modal/dialog.mock.ts
@@ -1,0 +1,54 @@
+/**
+ * Mock implementation for HTMLDialogElement methods in Jest tests.
+ *
+ * This mock provides:
+ * - show() and showModal() methods that set open=true
+ * - close() method that sets open=false and fires 'close' event
+ * - triggerCancel() method for testing cancel events (simulates ESC key)
+ *
+ * Usage in tests:
+ * ```tsx
+ * const dialog = screen.getByRole('dialog') as HTMLDialogElement
+ * dialog.triggerCancel() // Simulates ESC key press
+ * ```
+ */
+
+// Extend the HTMLDialogElement interface to include our custom method
+declare global {
+  interface HTMLDialogElement {
+    triggerCancel(): void
+  }
+}
+
+HTMLDialogElement.prototype.show = jest.fn(function mock(
+  this: HTMLDialogElement
+) {
+  this.open = true
+})
+
+HTMLDialogElement.prototype.showModal = jest.fn(function mock(
+  this: HTMLDialogElement
+) {
+  this.open = true
+})
+
+HTMLDialogElement.prototype.close = jest.fn(function mock(
+  this: HTMLDialogElement
+) {
+  this.open = false
+  // Fire the 'close' event
+  this.dispatchEvent(new Event('close', { bubbles: true }))
+})
+
+// Helper function to manually trigger cancel event for testing
+// This simulates what happens when ESC key is pressed
+HTMLDialogElement.prototype.triggerCancel = jest.fn(function mock(
+  this: HTMLDialogElement
+) {
+  this.open = false
+  // Fire the 'cancel' event
+  this.dispatchEvent(new Event('cancel', { bubbles: true }))
+})
+
+// Export to make this a module
+export {}

--- a/src/Modal/useAriaHidden.ts
+++ b/src/Modal/useAriaHidden.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+export const useAriaHidden = (
+  ref: React.RefObject<HTMLDialogElement>,
+  open?: boolean,
+  ariaHidden?: boolean
+) => {
+  const [iAriaHidden, setIAriaHidden] = useState(ariaHidden ?? !open)
+
+  useEffect(() => {
+    setIAriaHidden(ariaHidden ?? !open)
+  }, [ariaHidden, open])
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.addEventListener('close', () => {
+        setIAriaHidden(true)
+      })
+    }
+  }, [ref.current])
+
+  useEffect(() => {
+    if (ref.current) {
+      const originalShowModal = ref.current.showModal
+      ref.current.showModal = () => {
+        originalShowModal.call(ref.current)
+        setIAriaHidden(false)
+      }
+      const originalClose = ref.current.close
+      ref.current.close = () => {
+        originalClose.call(ref.current)
+        setIAriaHidden(true)
+      }
+    }
+  }, [ref.current])
+
+  return iAriaHidden
+}

--- a/src/Modal/useAriaHidden.ts
+++ b/src/Modal/useAriaHidden.ts
@@ -16,6 +16,9 @@ export const useAriaHidden = (
       ref.current.addEventListener('close', () => {
         setIAriaHidden(true)
       })
+      ref.current.addEventListener('cancel', () => {
+        setIAriaHidden(true)
+      })
     }
   }, [ref.current])
 


### PR DESCRIPTION
Closes https://github.com/daisyui/react-daisyui/issues/476

### Problem
Bit of a complex one; aria-hidden wasn't being set when using useDialog or using diallogRef.showModal(). On top of this, testing the modal was difficult because aria-hidden was blocking finding the dialog.

### Solution

I added useAriaHidden that handles a working order of operations to set aria-hidden and opening the modal without triggering the warning. I learned that aria-hidden needs to be set BEFORE calling showModal, else there's a race condition and the warning could still show up. Instead, I'm handling it by setting state which updates aria-hidden, then a useEffect that listens to that state change when *then* calls `showModal` or `close`. Finally, there's an event listener for close/cancel events that then sets aria-hidden to false.

### Notes

If we don't want to solve this here, I think documentation explaining that explicit state handling of aria-hidden is required during implementation would be a good alternative. Or... maybe just remove this and only support the open prop, since that works well and fighting this is clearly not fun.

Anyway, the fix:

https://github.com/user-attachments/assets/42f51578-deec-47f9-b6c6-d88b33f897b9

Note the lack of aria-hidden console warnings.