### PR TITLE
Use React.useCallback for useDialog Dialog component

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -87,13 +87,13 @@ const useDialog = () => {
     dialogRef.current?.close()
   }, [dialogRef])
 
-  const Dialog = ({ children, ...props }: DialogProps) => {
+  const Dialog = useCallback<React.FunctionComponent>(({ children, ...props }: DialogProps) => {
     return (
       <Modal {...props} ref={dialogRef}>
         {children}
       </Modal>
     )
-  }
+  }, [dialogRef])
   Dialog.displayName = 'Dialog'
   return { dialogRef, Dialog, handleShow, handleHide }
 }


### PR DESCRIPTION
Previously, if a component containing a `useDialog` hook would rerender, it would replace the Dialog wth a new component because it would redefine the component.

The consequences of this were that
- State changes would cause the dialog to close
- Form submission callbacks that alter the state close the dialog without any animation

Now, the component is memo'd and state changes do not recreate the dialog in the DOM